### PR TITLE
fixes bug where sequences w/ no people detected breaks things

### DIFF
--- a/labeling_interface.ipynb
+++ b/labeling_interface.ipynb
@@ -54,6 +54,7 @@
     "        \n",
     "    for seq in range(1,n_sequences+1):   \n",
     "        sequence_data = data[data[:,0]==seq,:]\n",
+    "        if len(sequence_data) == 0: continue # no drawing numbers on sequences w/ no people detected\n",
     "        beg_frame, end_frame = int(sequence_data[0,1]), int(sequence_data[-1,1])\n",
     "        for frame_num in range(beg_frame, end_frame+1):\n",
     "            # find the frame image to edit\n",


### PR DESCRIPTION
fixed a bug in labeling.ipynb that caused code to break when no people were detected in a sequence